### PR TITLE
add method to parse with probabilities

### DIFF
--- a/lib/utterance_parser/parser.rb
+++ b/lib/utterance_parser/parser.rb
@@ -47,6 +47,13 @@ module UtteranceParser
       [intent, extract_entities(labeled)]
     end
 
+    def parse_with_probabilities(text)
+      utterance = Utterance.new(text)
+      intents = @classifier.classify(utterance.pos_tokens)
+      labeled = @labeller.label([ utterance.pos_tokens.map { |t| t.join(" ") } ]).first
+      [intents, extract_entities(labeled)]
+    end
+
     def save(path=nil)
       build_save_paths path if path
 


### PR DESCRIPTION
Added a method `parse_with_probabilities`. This returns a hash of all classes with respective probabilities (instead of just the `max_class`). This would be useful when trying to determine the certainty of a prediction (or getting next-best results).